### PR TITLE
Initialize tools Array in BaseAgent Constructor

### DIFF
--- a/src/agents/baseAgent.js
+++ b/src/agents/baseAgent.js
@@ -14,7 +14,7 @@ import { AGENT_STATUS_enum } from '../utils/enums';
 import { REACT_CHAMPION_AGENT_DEFAULT_PROMPTS } from '../utils/prompts';
 
 class BaseAgent {
-    constructor({ name, role, goal, background, tools, llmConfig = {}, maxIterations = 10, forceFinalAnswer = true, promptTemplates = {}, llmInstance = null  }) {
+    constructor({ name, role, goal, background, tools = [], llmConfig = {}, maxIterations = 10, forceFinalAnswer = true, promptTemplates = {}, llmInstance = null  }) {
         this.id = uuidv4();
         this.name = name;
         this.role = role;

--- a/tests/e2e/examples/teams/product_specs/openai.js
+++ b/tests/e2e/examples/teams/product_specs/openai.js
@@ -13,7 +13,7 @@ const requirementsAnalyst = new Agent({
     role: 'Requirements Analyst', 
     goal: 'Outline core functionalities and objectives for new features based on the founder’s input.', 
     background: 'Business Analysis',
-    tools: []
+    // tools: []
 });
 
 const technicalWriter = new Agent({


### PR DESCRIPTION
**Problem**: 
Previously, the `BaseAgent` constructor did not explicitly initialize the `tools` array if it wasn't provided in the constructor parameters. This led to runtime errors when the `tools` property was accessed before being explicitly set elsewhere in the code.

**Solution**: 
This PR modifies the `BaseAgent` constructor to default the `tools` array to an empty array if not provided. This ensures all instances of `BaseAgent` start with a `tools` property initialized, preventing undefined access errors and aligning with our data structure expectations.

**Changes Made**:
- Added a default parameter in the `BaseAgent` constructor for `tools`, setting it to an empty array.
- Updated any relevant documentation to reflect this change.

**Impact**:
This change ensures that all agent instances are robustly initialized, improving the stability of our system and preventing potential bugs related to tool handling.

Thanks @zhaopengme for pointing this out in #97 

