### PR TITLE
Adds tool instalation to the CLI

### DIFF
--- a/xscripts/cli.mjs
+++ b/xscripts/cli.mjs
@@ -391,13 +391,13 @@ function isKaibanJSInstalled() {
 
 // Function to install KaibanJS
 function installKaibanJS() {
-  const spinner = ora('Installing KaibanJS...').start();
+  const spinner = ora('Installing KaibanJS and tools...').start();
   try {
-    execSync('npm install kaibanjs --legacy-peer-deps', { stdio: 'inherit' });
-    spinner.succeed('KaibanJS installed successfully.');
+    execSync('npm install kaibanjs @kaibanjs/tools --legacy-peer-deps', { stdio: 'inherit' });
+    spinner.succeed('KaibanJS and tools installed successfully.');
   } catch (error) {
-    spinner.fail('Failed to install KaibanJS.');
-    console.error(chalk.red('Error installing KaibanJS:'), error);
+    spinner.fail('Failed to install KaibanJS and tools.');
+    console.error(chalk.red('Error installing packages:'), error);
     process.exit(1);
   }
 }


### PR DESCRIPTION
### Description
This PR enhances the KaibanJS CLI by including `@kaibanjs/tools` installation during the KaibanJS installation process. The installation function now installs both `kaibanjs` and `@kaibanjs/tools` packages, providing users with a more complete setup experience.

### Changes
- Modified `installKaibanJS` function in `xscripts/cli.mjs` to install `@kaibanjs/tools` along with `kaibanjs`.
- Updated spinner and error messages to reflect the change.

### Impact
This change simplifies the installation process by automating the setup of essential tools alongside KaibanJS.

### Test Plan
- Verified that running the CLI with the modified install command installs both `kaibanjs` and `@kaibanjs/tools`.