### PR TITLE
don't let "npx kaiban init" start the server, that's the duty of "npx kaiban dev"!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ server.js
 
 # Generated files from MoscaFetch
 recordedData.json
+
+.kaiban

--- a/xscripts/cli.mjs
+++ b/xscripts/cli.mjs
@@ -542,7 +542,7 @@ async function main() {
     if (command === 'init') {
       await initKaibanProject();
       td.signal('init_board');
-      runKaibanServer();
+//      runKaibanServer();
     } else {
       await initKaibanProject();
       td.signal('run_board');


### PR DESCRIPTION
According to the docs, `npx kaiban init` should not start the Kaiban server - it should just initialized the system and then allow users to enter their credentials into a `.env` file.

Additionally, you probably don't want to commit changes within the `.kaiban` folder...