### PR TITLE
Update release-test workflow name and clean up package dependencies

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,4 +1,4 @@
-name: Release Version
+name: Release Version Test
 
 on:
   workflow_dispatch:
@@ -98,5 +98,3 @@ jobs:
 
       - name: Update package.json version and create Git tag
         run: npm version ${{ github.event.inputs.version }}
-
-

--- a/packages/workflow/package-lock.json
+++ b/packages/workflow/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@kaibanjs/workflow",
       "version": "0.1.0",
       "dependencies": {
-        "@kaibanjs/tools": "../tools",
         "@langchain/community": "^0.3.46",
         "@langchain/core": "^0.3.58",
         "@langchain/openai": "^0.5.13",
@@ -33,6 +32,7 @@
     "../tools": {
       "name": "@kaibanjs/tools",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@langchain/community": "0.3.41",
@@ -890,10 +890,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/@kaibanjs/tools": {
-      "resolved": "../tools",
-      "link": true
     },
     "node_modules/@langchain/community": {
       "version": "0.3.46",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -22,7 +22,6 @@
     "snapshot-demo": "tsx src/examples/snapshot-example.tsx"
   },
   "dependencies": {
-    "@kaibanjs/tools": "../tools",
     "@langchain/community": "^0.3.46",
     "@langchain/core": "^0.3.58",
     "@langchain/openai": "^0.5.13",


### PR DESCRIPTION
- Changed the name of the release workflow from "Release Version" to "Release Version Test" for clarity.
- Removed the local dependency on "@kaibanjs/tools" from both package.json and package-lock.json to streamline the dependency management.
- Marked "@kaibanjs/tools" as extraneous in package-lock.json to reflect its removal.