### PR TITLE
Update dependencies in package.json and package-lock.json

### DIFF
--- a/.github/workflows/workflow-release.yml
+++ b/.github/workflows/workflow-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '22'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Reset local changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
-        "@kaibanjs/workflow": "^0.1.4",
+        "@kaibanjs/workflow": "^0.1.5",
         "@langchain/anthropic": "^0.3.19",
         "@langchain/community": "0.3.41",
         "@langchain/core": "^0.3.66",
@@ -80,9 +80,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "../packages/workflow": {
-      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -2601,12 +2598,12 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.1.tgz",
+      "integrity": "sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -2614,14 +2611,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
+        "protobufjs": "^7.5.3",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3446,9 +3443,9 @@
       }
     },
     "node_modules/@kaibanjs/workflow": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@kaibanjs/workflow/-/workflow-0.1.4.tgz",
-      "integrity": "sha512-eSLFJqvQmtxexKvJ93cwV9d6e3yZ2em5M2vNd4pA8o70bT+HTLvEeM+c5EKV4iEg5aYufe2+Fs/1ash8Im4S7A==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@kaibanjs/workflow/-/workflow-0.1.5.tgz",
+      "integrity": "sha512-DmIm4gOOmyPaeVbtgixXmHIpx6e72so3LaWMnU/vL95JZbXtrGvOX2LBMV+dasDWr7qSmuHwin5H7F3WtsNuZg==",
       "dependencies": {
         "@langchain/community": "^0.3.46",
         "@langchain/core": "^0.3.58",
@@ -3463,19 +3460,19 @@
       }
     },
     "node_modules/@kaibanjs/workflow/node_modules/@langchain/community": {
-      "version": "0.3.53",
-      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.53.tgz",
-      "integrity": "sha512-TlQzXXuiqPkpALvvuClzt6K83EQ2oA+0B/UzWrrWQPCYpJtfy5kbT/Uwc4PPa8twdVUNpLcXgFaLtb3U1EXVAg==",
+      "version": "0.3.58",
+      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.58.tgz",
+      "integrity": "sha512-jrMbv1Xz2yqcWtlj+wnMmbagIK6J/fbQdP6R+Az+e+er5CeWy2eZHKBGFL5XYbAzYJdYhAbA4gt8kwVT6oaZfw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/openai": ">=0.2.0 <0.7.0",
         "@langchain/weaviate": "^0.2.0",
         "binary-extensions": "^2.2.0",
-        "expr-eval": "^2.0.2",
         "flat": "^5.0.2",
         "js-yaml": "^4.1.0",
         "langchain": ">=0.2.3 <0.3.0 || >=0.3.4 <0.4.0",
-        "langsmith": "^0.3.46",
+        "langsmith": "^0.3.67",
+        "math-expression-evaluator": "^2.0.0",
         "uuid": "^10.0.0",
         "zod": "^3.25.32"
       },
@@ -3513,7 +3510,7 @@
         "@huggingface/inference": "^4.0.5",
         "@huggingface/transformers": "^3.5.2",
         "@ibm-cloud/watsonx-ai": "*",
-        "@lancedb/lancedb": "^0.12.0",
+        "@lancedb/lancedb": "^0.19.1",
         "@langchain/core": ">=0.3.58 <0.4.0",
         "@layerup/layerup-security": "^1.5.12",
         "@libsql/client": "^0.14.0",
@@ -3562,11 +3559,10 @@
         "crypto-js": "^4.2.0",
         "d3-dsv": "^2.0.0",
         "discord.js": "^14.14.1",
-        "dria": "^0.0.3",
         "duck-duck-scrape": "^2.2.5",
         "epub2": "^3.0.1",
         "fast-xml-parser": "*",
-        "firebase-admin": "^11.9.0 || ^12.0.0",
+        "firebase-admin": "^11.9.0 || ^12.0.0 || ^13.0.0",
         "google-auth-library": "*",
         "googleapis": "*",
         "hnswlib-node": "^3.0.0",
@@ -3844,9 +3840,6 @@
         "discord.js": {
           "optional": true
         },
-        "dria": {
-          "optional": true
-        },
         "duck-duck-scrape": {
           "optional": true
         },
@@ -3994,9 +3987,9 @@
       "license": "MIT"
     },
     "node_modules/@kaibanjs/workflow/node_modules/langchain": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.31.tgz",
-      "integrity": "sha512-C7n7WGa44RytsuxEtGcArVcXidRqzjl6UWQxaG3NdIw4gIqErWoOlNC1qADAa04H5JAOARxuE6S99+WNXB/rzA==",
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.36.tgz",
+      "integrity": "sha512-PqC19KChFF0QlTtYDFgfEbIg+SCnCXox29G8tY62QWfj9bOW7ew2kgWmPw5qoHLOTKOdQPvXET20/1Pdq8vAtQ==",
       "license": "MIT",
       "dependencies": {
         "@langchain/openai": ">=0.1.0 <0.7.0",
@@ -4004,7 +3997,7 @@
         "js-tiktoken": "^1.0.12",
         "js-yaml": "^4.1.0",
         "jsonpointer": "^5.0.1",
-        "langsmith": "^0.3.46",
+        "langsmith": "^0.3.67",
         "openapi-types": "^12.1.3",
         "p-retry": "4",
         "uuid": "^10.0.0",
@@ -4904,9 +4897,9 @@
       }
     },
     "node_modules/@langchain/weaviate": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@langchain/weaviate/-/weaviate-0.2.2.tgz",
-      "integrity": "sha512-nMkK4ZwfKjQR98kzpL/PPdFixdmD/KX89lZ9R5rhEShv3nfVyfGW8bVMpmC91kqIWxsjeqaqUZ1ZAdzpZRnE/w==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/weaviate/-/weaviate-0.2.3.tgz",
+      "integrity": "sha512-WqNGn1eSrI+ZigJd7kZjCj3fvHBYicKr054qts2nNJ+IyO5dWmY3oFTaVHFq1OLFVZJJxrFeDnxSEOC3JnfP0w==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0",
@@ -10034,9 +10027,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -12752,9 +12745,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.48",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.48.tgz",
-      "integrity": "sha512-oEsj0Z8S2Chgb3vJzRX2vplLu4RWR1cpraIaVwv2PsNZ57VbHgZEdXdeh5kh16iP8PAv04JkBncP+KLRoKBFEw==",
+      "version": "0.3.81",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.81.tgz",
+      "integrity": "sha512-NFmp7TDrrbCE6TIfHqutN9xhdgvx0EOhULVo8bDW+ib5idprwjMTvmS0S1n9uVFwjN03zU2zVEWViXnwy5XPrw==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -13484,6 +13477,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-expression-evaluator": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-2.0.7.tgz",
+      "integrity": "sha512-uwliJZ6BPHRq4eiqNWxZBDzKUiS5RIynFFcgchqhBOloVLVBpZpNG8jRYkedLcBvhph8TnRyWEuxPqiQcwIdog==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -13680,20 +13679,20 @@
       "peer": true
     },
     "node_modules/nice-grpc": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.12.tgz",
-      "integrity": "sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw==",
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.14.tgz",
+      "integrity": "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww==",
       "license": "MIT",
       "dependencies": {
-        "@grpc/grpc-js": "^1.13.1",
+        "@grpc/grpc-js": "^1.14.0",
         "abort-controller-x": "^0.4.0",
         "nice-grpc-common": "^2.0.2"
       }
     },
     "node_modules/nice-grpc-client-middleware-retry": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.11.tgz",
-      "integrity": "sha512-xW/imz/kNG2g0DwTfH2eYEGrg1chSLrXtvGp9fg2qkhTgGFfAS/Pq3+t+9G8KThcC4hK/xlEyKvZWKk++33S6A==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.13.tgz",
+      "integrity": "sha512-Q9I/wm5lYkDTveKFirrTHBkBY137yavXZ4xQDXTPIycUp7aLXD8xPTHFhqtAFWUw05aS91uffZZRgdv3HS0y/g==",
       "license": "MIT",
       "dependencies": {
         "abort-controller-x": "^0.4.0",
@@ -17274,9 +17273,9 @@
       }
     },
     "node_modules/weaviate-client": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.8.1.tgz",
-      "integrity": "sha512-/bH5SO31gGGiI5RhvOEwQBs2DtORsssVjenWxdOQzGToAdmqRC4Oo9HZLIITX5BdFD0IqKDnY81nOZlJlHzn+g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.9.0.tgz",
+      "integrity": "sha512-7qwg7YONAaT4zWnohLrFdzky+rZegVe76J+Tky/+7tuyvjFpdKgSrdqI/wPDh8aji0ZGZrL4DdGwGfFnZ+uV4w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "abort-controller-x": "^0.4.3",
@@ -17913,82 +17912,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "packages/tools": {
-      "name": "@kaibanjs/tools",
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/community": "0.3.41",
-        "@langchain/core": "0.3.49",
-        "@langchain/openai": "^0.5.7",
-        "cheerio": "^1.0.0",
-        "ky": "^1.7.2",
-        "langchain": "0.3.24",
-        "pdf-parse": "^1.1.1",
-        "pdfjs-dist": "^4.8.69",
-        "zod": "3.24.3"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.25.9",
-        "@babel/preset-env": "^7.26.0",
-        "@chromatic-com/storybook": "^1.9.0",
-        "@rollup/plugin-commonjs": "^25.0.8",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.3.0",
-        "@rollup/plugin-replace": "^6.0.1",
-        "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "^12.1.2",
-        "@storybook/addon-essentials": "^8.3.6",
-        "@storybook/addon-interactions": "^8.3.6",
-        "@storybook/addon-links": "^8.3.6",
-        "@storybook/addon-onboarding": "^8.3.6",
-        "@storybook/blocks": "^8.3.6",
-        "@storybook/react": "^8.3.6",
-        "@storybook/react-vite": "^8.3.6",
-        "@storybook/test": "^8.3.6",
-        "@types/node": "^22.13.4",
-        "babel-jest": "^29.7.0",
-        "eslint": "^8.4.1",
-        "eslint-plugin-storybook": "^0.10.1",
-        "jest": "^27.5.1",
-        "prop-types": "^15.8.1",
-        "react-monaco-editor": "^0.56.2",
-        "rollup": "^4.24.0",
-        "rollup-plugin-node-polyfills": "^0.2.1",
-        "storybook": "^8.3.6",
-        "tslib": "^2.8.1",
-        "typescript": "^5.7.3",
-        "undici": "^6.20.1"
-      }
-    },
-    "packages/workflow": {
-      "name": "@kaibanjs/workflow",
-      "version": "0.1.0",
-      "extraneous": true,
-      "dependencies": {
-        "@kaibanjs/tools": "../tools",
-        "@langchain/community": "^0.3.46",
-        "@langchain/core": "^0.3.58",
-        "@langchain/openai": "^0.5.13",
-        "langchain": "^0.3.28",
-        "p-queue": "^6.6.2",
-        "zod": "^3.22.4",
-        "zustand": "4.5.2"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.19",
-        "eslint": "^8.56.0",
-        "prettier": "^3.2.5",
-        "tsup": "^8.0.2",
-        "tsx": "^4.19.4",
-        "typescript": "^5.3.3",
-        "vitest": "^1.2.2"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "nextjs"
   ],
   "dependencies": {
-    "@kaibanjs/workflow": "^0.1.4",
+    "@kaibanjs/workflow": "^0.1.5",
     "@langchain/anthropic": "^0.3.19",
     "@langchain/community": "0.3.41",
     "@langchain/core": "^0.3.66",


### PR DESCRIPTION
- Upgraded "@kaibanjs/workflow" to version 0.1.5.
- Updated various dependencies including "@grpc/grpc-js" to 1.14.1, "@grpc/proto-loader" to 0.8.0, and "langsmith" to 0.3.81.
- Adjusted Node.js version in workflow from 22 to 18 for compatibility.