### PR TITLE
Fix #273: Audit trails for multi-agent task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,9 @@ console.log(writtenBy);
 Projects built by the KaibanJS community that extend the ecosystem:
 
 - [kaiban-distributed](https://github.com/andreibesleaga/kaiban-distributed) - Distributed actor-model runtime for KaibanJS teams with Redis/Kafka messaging, A2A/MCP integration, and real-time board synchronization.
+- [asqav](https://asqav.com) - Cryptographic audit trails for multi-agent task execution. Signs each task transition, agent handoff, and output so teams can prove their system's decisions to auditors or stakeholders.
 
-> Community-maintained project: ownership, roadmap, and support are managed by the project author.
+> Community-maintained projects: ownership, roadmap, and support are managed by the respective project authors.
 
 ## Community and Support
 


### PR DESCRIPTION
Closes #273

## Motivation

Issue #273 identified a need for cryptographic audit trails in multi-agent workflows. The community ecosystem section in `README.md` lacked a listing for `asqav`, which provides signed records for task transitions, agent handoffs, and outputs in KaibanJS deployments.

## Changes

**`README.md`, line ~609** — Adds `asqav` to the community projects list between `kaiban-distributed` and the community-maintained disclaimer. The entry links to `https://asqav.com` and describes its core value: cryptographic signing of each task transition, agent handoff, and output for auditability.

**`README.md`, line ~612** — Updates the disclaimer from singular ("Community-maintained project") to plural ("Community-maintained projects") and from "the project author" to "the respective project authors", accurately reflecting that there are now multiple community-maintained entries in this section.

## Testing

Manual verification steps:
1. Render `README.md` and confirm the `asqav` bullet appears in the correct position within the "Community Projects" section, after `kaiban-distributed`.
2. Confirm the link `https://asqav.com` resolves and the description accurately reflects the project's functionality.
3. Confirm the disclaimer immediately below the list reads "Community-maintained projects" (plural) with "respective project authors" — no leftover singular phrasing.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*