### PR TITLE
feat: add PerplexitySearch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Just as professionals use specific tools to excel in their tasks, enable your AI
 
 In this example, one of the AI agents, Peter Atlas, leverages the Tavily Search Results tool to enhance his ability to select the best cities for travel. This tool allows Peter to analyze travel data considering weather, prices, and seasonality, ensuring the most suitable recommendations.
 
+> **Recommended for new projects:** Use [`PerplexitySearch`](packages/tools/src/perplexity-search/README.md) from `@kaibanjs/tools` as your default web search tool — single API key (`PERPLEXITY_API_KEY`), snippets pre-ranked for LLM grounding, with built-in domain and recency filters.
+
 </p>
 
 ```js

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -38,6 +38,7 @@ Here's a list of all available tools. Click on the tool names to view their deta
 | WolframAlpha        | Computational intelligence engine for complex queries and calculations          | [README](src/wolfram-alpha/README.md)        |
 | Zapier Webhook      | Integration with Zapier for workflow automation                                 | [README](src/zapier-webhook/README.md)       |
 | Make Webhook        | Integration with Make (formerly Integromat) for workflow automation             | [README](src/make-webhook/README.md)         |
+| Perplexity Search   | Web search via the Perplexity Search API with domain and recency filters        | [README](src/perplexity-search/README.md)    |
 | Simple RAG Retrieve | Basic Retrieval-Augmented Generation implementation for Q&A with preloaded data | [README](src/simple-rag-retrieve/README.md)  |
 
 ## Development

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -23,23 +23,25 @@ npm install @kaibanjs/tools
 
 Here's a list of all available tools. Click on the tool names to view their detailed documentation.
 
-| Tool                | Description                                                                     | Documentation                                |
-| ------------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
-| Exa                 | AI-focused search engine using embeddings to organize web data                  | [README](src/exa/README.md)                  |
-| Firecrawl           | Web scraping service for extracting structured data                             | [README](src/firecrawl/README.md)            |
-| GitHub Issues       | GitHub API integration for fetching and analyzing repository issues             | [README](src/github-issues/README.md)        |
-| Jina URL to MD      | Convert web content into clean, LLM-ready markdown using Jina.ai                | [README](src/jina-url-to-markdown/README.md) |
-| PDF Search          | Extract and search content from PDF documents                                   | [README](src/pdf-search/README.md)           |
-| Serper              | Google Search API integration with support for multiple search types            | [README](src/serper/README.md)               |
-| Simple RAG          | Basic Retrieval-Augmented Generation implementation for Q&A                     | [README](src/simple-rag/README.md)           |
-| Tavily Search       | AI-optimized search engine for comprehensive and accurate results               | [README](src/tavily/README.md)               |
-| Text File Search    | Search and analyze content within text files                                    | [README](src/textfile-search/README.md)      |
-| Website Search      | Semantic search within website content using RAG models                         | [README](src/website-search/README.md)       |
-| WolframAlpha        | Computational intelligence engine for complex queries and calculations          | [README](src/wolfram-alpha/README.md)        |
-| Zapier Webhook      | Integration with Zapier for workflow automation                                 | [README](src/zapier-webhook/README.md)       |
-| Make Webhook        | Integration with Make (formerly Integromat) for workflow automation             | [README](src/make-webhook/README.md)         |
-| Perplexity Search   | Web search via the Perplexity Search API with domain and recency filters        | [README](src/perplexity-search/README.md)    |
-| Simple RAG Retrieve | Basic Retrieval-Augmented Generation implementation for Q&A with preloaded data | [README](src/simple-rag-retrieve/README.md)  |
+> **Recommended for general web search:** `PerplexitySearch` — single API key, snippets pre-ranked for LLM grounding, with domain and recency filters. Set `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) and you're done.
+
+| Tool                          | Description                                                                     | Documentation                                |
+| ----------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
+| Perplexity Search (recommended) | Web search via the Perplexity Search API with domain and recency filters        | [README](src/perplexity-search/README.md)    |
+| Exa                           | AI-focused search engine using embeddings to organize web data                  | [README](src/exa/README.md)                  |
+| Firecrawl                     | Web scraping service for extracting structured data                             | [README](src/firecrawl/README.md)            |
+| GitHub Issues                 | GitHub API integration for fetching and analyzing repository issues             | [README](src/github-issues/README.md)        |
+| Jina URL to MD                | Convert web content into clean, LLM-ready markdown using Jina.ai                | [README](src/jina-url-to-markdown/README.md) |
+| PDF Search                    | Extract and search content from PDF documents                                   | [README](src/pdf-search/README.md)           |
+| Serper                        | Google Search API integration with support for multiple search types            | [README](src/serper/README.md)               |
+| Simple RAG                    | Basic Retrieval-Augmented Generation implementation for Q&A                     | [README](src/simple-rag/README.md)           |
+| Tavily Search                 | AI-optimized search engine for comprehensive and accurate results               | [README](src/tavily/README.md)               |
+| Text File Search              | Search and analyze content within text files                                    | [README](src/textfile-search/README.md)      |
+| Website Search                | Semantic search within website content using RAG models                         | [README](src/website-search/README.md)       |
+| WolframAlpha                  | Computational intelligence engine for complex queries and calculations          | [README](src/wolfram-alpha/README.md)        |
+| Zapier Webhook                | Integration with Zapier for workflow automation                                 | [README](src/zapier-webhook/README.md)       |
+| Make Webhook                  | Integration with Make (formerly Integromat) for workflow automation             | [README](src/make-webhook/README.md)         |
+| Simple RAG Retrieve           | Basic Retrieval-Augmented Generation implementation for Q&A with preloaded data | [README](src/simple-rag-retrieve/README.md)  |
 
 ## Development
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -76,6 +76,11 @@
       "types": "./dist/simple-rag-retrieve/index.d.ts",
       "import": "./dist/simple-rag-retrieve/index.esm.js",
       "require": "./dist/simple-rag-retrieve/index.cjs.js"
+    },
+    "./perplexity-search": {
+      "types": "./dist/perplexity-search/index.d.ts",
+      "import": "./dist/perplexity-search/index.esm.js",
+      "require": "./dist/perplexity-search/index.cjs.js"
     }
   },
   "files": [

--- a/packages/tools/rollup.config.mjs
+++ b/packages/tools/rollup.config.mjs
@@ -23,6 +23,7 @@ const toolFolders = [
   'make-webhook',
   'jina-url-to-markdown',
   'simple-rag-retrieve',
+  'perplexity-search',
 ]; // Add more folder names as needed
 
 const toolConfigs = toolFolders.map((tool) => {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -15,5 +15,6 @@ export { GithubIssues } from './github-issues';
 export { Serper } from './serper';
 export { WolframAlphaTool } from './wolfram-alpha';
 export { ExaSearch } from './exa';
+export { PerplexitySearch } from './perplexity-search';
 export { SimpleRAGRetrieve } from './simple-rag-retrieve';
 export { RAGToolkit } from './_utils/rag/ragToolkit';

--- a/packages/tools/src/perplexity-search/README.md
+++ b/packages/tools/src/perplexity-search/README.md
@@ -1,0 +1,65 @@
+# Perplexity Search Tool
+
+This tool integrates KaibanJS agents with the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post), a web search API that returns ranked results (title, URL, snippet, and optional publication date) suitable for grounding LLM agents in fresh, citation-friendly content.
+
+## Components
+
+- A `Bearer` API key for authentication (`PERPLEXITY_API_KEY` or `PPLX_API_KEY`)
+- A custom HTTP client (ky) for making API requests
+- Input validation using Zod schema
+- Configurable maximum results, domain filter, and recency filter
+
+## Key Features
+
+- Returns structured search results: `{ title, url, snippet, date? }`
+- Configurable `maxResults` (default `10`)
+- Optional `searchDomainFilter` — allow or deny list (use `-domain.com` to deny). Do not mix allow and deny entries.
+- Optional `searchRecencyFilter` — `hour | day | week | month | year`
+- Built-in error handling for HTTP and network errors
+
+## Input
+
+The input is a JSON object with a `searchQuery` field containing the query string.
+
+## Output
+
+A JSON-formatted string containing an array of search result objects.
+
+## Example
+
+```javascript
+import { PerplexitySearch } from '@kaibanjs/tools';
+
+const tool = new PerplexitySearch({
+  apiKey: process.env.PERPLEXITY_API_KEY, // or set PERPLEXITY_API_KEY / PPLX_API_KEY
+  maxResults: 5,
+  searchRecencyFilter: 'week',
+});
+
+const result = await tool._call({
+  searchQuery: 'What are the latest developments in AI?',
+});
+
+const results = JSON.parse(result);
+results.forEach((r, i) => console.log(`${i + 1}. ${r.title} — ${r.url}`));
+```
+
+## Domain Filter Example
+
+```javascript
+const tool = new PerplexitySearch({
+  apiKey: process.env.PERPLEXITY_API_KEY,
+  searchDomainFilter: ['nytimes.com', 'reuters.com'], // allow-list
+  // or: ['-pinterest.com', '-quora.com'] // deny-list — do not mix the two
+});
+```
+
+## Get an API Key
+
+Create a key at <https://www.perplexity.ai/account/api/keys>.
+
+## Reference
+
+- API reference: <https://docs.perplexity.ai/api-reference/search-post>
+- Domain filter docs: <https://docs.perplexity.ai/docs/search/filters/domain-filter>
+- Date / recency filter docs: <https://docs.perplexity.ai/docs/search/filters/date-time-filters>

--- a/packages/tools/src/perplexity-search/index.js
+++ b/packages/tools/src/perplexity-search/index.js
@@ -1,0 +1,119 @@
+/**
+ * Perplexity Search
+ *
+ * This tool integrates with the Perplexity Search API
+ * (https://docs.perplexity.ai/api-reference/search-post), a web search API
+ * that returns ranked search results (title, URL, snippet, optional date)
+ * suitable for grounding LLM agents in fresh, citation-friendly web content.
+ *
+ * Key features:
+ * - Configurable maximum number of results
+ * - Optional domain allow / deny filter (use a leading "-" to deny)
+ * - Optional recency filter (hour | day | week | month | year)
+ * - Returns structured results: { title, url, snippet, date? }
+ *
+ * Auth: pass `apiKey` directly, or set `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`)
+ * in the environment. Get an API key at https://www.perplexity.ai/account/api/keys.
+ *
+ * Usage:
+ * const tool = new PerplexitySearch({
+ *   apiKey: 'your-api-key',
+ *   maxResults: 5,
+ *   searchRecencyFilter: 'week',
+ * });
+ * const json = await tool._call({ searchQuery: 'latest AI breakthroughs' });
+ * const results = JSON.parse(json);
+ */
+
+import { Tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import ky from 'ky';
+import { HTTPError } from 'ky';
+
+const API_URL = 'https://api.perplexity.ai/search';
+
+export class PerplexitySearch extends Tool {
+  constructor(fields = {}) {
+    super(fields);
+
+    const apiKey =
+      fields.apiKey ||
+      (typeof process !== 'undefined' && process.env
+        ? process.env.PERPLEXITY_API_KEY || process.env.PPLX_API_KEY
+        : undefined);
+
+    if (!apiKey) {
+      throw new Error(
+        'PerplexitySearch: missing API key. Pass `apiKey` or set PERPLEXITY_API_KEY (or PPLX_API_KEY) in the environment.'
+      );
+    }
+
+    this.apiKey = apiKey;
+    this.maxResults = fields.maxResults ?? 10;
+    this.searchDomainFilter = fields.searchDomainFilter;
+    this.searchRecencyFilter = fields.searchRecencyFilter;
+
+    this.name = 'perplexity-search';
+    this.description =
+      'A web search tool powered by the Perplexity Search API. Returns ranked search results with title, URL, snippet, and optional publication date. Useful for retrieving fresh, citation-friendly information about current events, research, or any topic that benefits from up-to-date web sources. Input should be a search query.';
+
+    this.httpClient = ky;
+    this.schema = z.object({
+      searchQuery: z
+        .string()
+        .describe('The search query to send to the Perplexity Search API.'),
+    });
+  }
+
+  async _call(input) {
+    const body = {
+      query: input.searchQuery,
+      max_results: this.maxResults,
+    };
+
+    if (this.searchDomainFilter && this.searchDomainFilter.length > 0) {
+      body.search_domain_filter = this.searchDomainFilter;
+    }
+    if (this.searchRecencyFilter) {
+      body.search_recency_filter = this.searchRecencyFilter;
+    }
+
+    try {
+      const json = await this.httpClient
+        .post(API_URL, {
+          json: body,
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+        .json();
+
+      const results = json?.results;
+      if (!Array.isArray(results)) {
+        return 'Could not parse Perplexity search results. Please try again.';
+      }
+
+      const normalized = results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.snippet,
+        ...(r.date ? { date: r.date } : {}),
+      }));
+
+      return JSON.stringify(normalized);
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const statusCode = error.response.status;
+        let errorType = 'Unknown';
+        if (statusCode >= 400 && statusCode < 500) {
+          errorType = 'Client Error';
+        } else if (statusCode >= 500) {
+          errorType = 'Server Error';
+        }
+        return `API request failed: ${errorType} (${statusCode})`;
+      }
+      return `An unexpected error occurred: ${error.message}`;
+    }
+  }
+}

--- a/packages/tools/src/perplexity-search/index.ts
+++ b/packages/tools/src/perplexity-search/index.ts
@@ -1,0 +1,183 @@
+/**
+ * Perplexity Search
+ *
+ * This tool integrates with the Perplexity Search API
+ * (https://docs.perplexity.ai/api-reference/search-post), a web search API
+ * that returns ranked search results (title, URL, snippet, optional date)
+ * suitable for grounding LLM agents in fresh, citation-friendly web content.
+ *
+ * Key features:
+ * - Configurable maximum number of results
+ * - Optional domain allow / deny filter (use a leading "-" to deny)
+ * - Optional recency filter (hour | day | week | month | year)
+ * - Returns structured results: { title, url, snippet, date? }
+ *
+ * Auth: pass `apiKey` directly, or set `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`)
+ * in the environment. Get an API key at https://www.perplexity.ai/account/api/keys.
+ */
+
+import { StructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import ky, { HTTPError } from 'ky';
+
+const API_URL = 'https://api.perplexity.ai/search';
+
+/**
+ * A single search result returned by the Perplexity Search API.
+ */
+type PerplexitySearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+  date?: string;
+};
+
+/**
+ * Recency filter accepted by the Perplexity Search API.
+ */
+type PerplexityRecencyFilter = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+/**
+ * Configuration options for PerplexitySearch.
+ *
+ * - `apiKey`: Perplexity API key. If omitted, the tool reads
+ *   `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) from the process environment.
+ * - `maxResults`: Maximum number of results to return (default 10).
+ * - `searchDomainFilter`: Allow OR deny list of domains. Use a leading "-"
+ *   to deny (e.g. `-pinterest.com`). Do NOT mix allow and deny entries —
+ *   pick one mode per request.
+ * - `searchRecencyFilter`: Restrict to results from the given recency window.
+ */
+interface PerplexitySearchFields {
+  apiKey?: string;
+  maxResults?: number;
+  searchDomainFilter?: string[];
+  searchRecencyFilter?: PerplexityRecencyFilter;
+}
+
+/**
+ * Input parameters accepted by the tool's `_call` method.
+ */
+interface PerplexitySearchParams {
+  searchQuery: string;
+}
+
+interface PerplexityRequestBody {
+  query: string;
+  max_results: number;
+  search_domain_filter?: string[];
+  search_recency_filter?: PerplexityRecencyFilter;
+}
+
+interface PerplexityApiResponse {
+  results?: PerplexitySearchResult[];
+}
+
+/**
+ * PerplexitySearch tool — wraps `POST https://api.perplexity.ai/search`.
+ *
+ * @example
+ * ```ts
+ * const tool = new PerplexitySearch({
+ *   apiKey: process.env.PERPLEXITY_API_KEY,
+ *   maxResults: 5,
+ *   searchRecencyFilter: 'week',
+ * });
+ *
+ * const json = await tool._call({ searchQuery: 'latest AI breakthroughs' });
+ * const results = JSON.parse(json);
+ * ```
+ */
+export class PerplexitySearch extends StructuredTool {
+  private apiKey: string;
+  private maxResults: number;
+  private searchDomainFilter?: string[];
+  private searchRecencyFilter?: PerplexityRecencyFilter;
+  private httpClient: typeof ky;
+
+  name = 'perplexity-search';
+  description =
+    'A web search tool powered by the Perplexity Search API. Returns ranked search results with title, URL, snippet, and optional publication date. Useful for retrieving fresh, citation-friendly information about current events, research, or any topic that benefits from up-to-date web sources. Input should be a search query.';
+
+  schema = z.object({
+    searchQuery: z
+      .string()
+      .describe('The search query to send to the Perplexity Search API.'),
+  });
+
+  constructor(fields: PerplexitySearchFields = {}) {
+    super();
+
+    const apiKey =
+      fields.apiKey ||
+      (typeof process !== 'undefined' && process.env
+        ? process.env.PERPLEXITY_API_KEY || process.env.PPLX_API_KEY
+        : undefined);
+
+    if (!apiKey) {
+      throw new Error(
+        'PerplexitySearch: missing API key. Pass `apiKey` or set PERPLEXITY_API_KEY (or PPLX_API_KEY) in the environment.'
+      );
+    }
+
+    this.apiKey = apiKey;
+    this.maxResults = fields.maxResults ?? 10;
+    this.searchDomainFilter = fields.searchDomainFilter;
+    this.searchRecencyFilter = fields.searchRecencyFilter;
+    this.httpClient = ky;
+  }
+
+  async _call(input: PerplexitySearchParams): Promise<string> {
+    const body: PerplexityRequestBody = {
+      query: input.searchQuery,
+      max_results: this.maxResults,
+    };
+
+    if (this.searchDomainFilter && this.searchDomainFilter.length > 0) {
+      body.search_domain_filter = this.searchDomainFilter;
+    }
+    if (this.searchRecencyFilter) {
+      body.search_recency_filter = this.searchRecencyFilter;
+    }
+
+    try {
+      const json = await this.httpClient
+        .post(API_URL, {
+          json: body,
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        })
+        .json<PerplexityApiResponse>();
+
+      const results = json?.results;
+      if (!Array.isArray(results)) {
+        return 'Could not parse Perplexity search results. Please try again.';
+      }
+
+      const normalized: PerplexitySearchResult[] = results.map((r) => ({
+        title: r.title,
+        url: r.url,
+        snippet: r.snippet,
+        ...(r.date ? { date: r.date } : {}),
+      }));
+
+      return JSON.stringify(normalized);
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const statusCode = error.response.status;
+        let errorType = 'Unknown';
+        if (statusCode >= 400 && statusCode < 500) {
+          errorType = 'Client Error';
+        } else if (statusCode >= 500) {
+          errorType = 'Server Error';
+        }
+        return `API request failed: ${errorType} (${statusCode})`;
+      }
+      return `An unexpected error occurred: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+  }
+}

--- a/packages/tools/src/perplexity-search/tool.stories.jsx
+++ b/packages/tools/src/perplexity-search/tool.stories.jsx
@@ -1,0 +1,69 @@
+import { ToolPreviewer } from '../_utils/ToolPreviewer.jsx';
+import { PerplexitySearch } from './index.ts';
+import { Agent, Task, Team } from '../../../../';
+import React from 'react';
+import { AgentWithToolPreviewer } from '../_utils/AgentWithToolPreviewer.jsx';
+
+export default {
+  title: 'Tools/PerplexitySearch',
+  component: ToolPreviewer,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+const perplexityTool = new PerplexitySearch({
+  apiKey: import.meta.env.VITE_PERPLEXITY_API_KEY,
+  maxResults: 5,
+});
+
+const searchResearcher = new Agent({
+  name: 'Search Researcher',
+  role: 'Web Search Analyzer',
+  goal: 'Perform web searches and analyze the results',
+  tools: [perplexityTool],
+  maxIterations: 5,
+  llmConfig: {
+    provider: 'google',
+    model: 'gemini-1.5-pro',
+  },
+});
+
+const searchAnalysisTask = new Task({
+  description:
+    'Performs a web search for: {searchQuery} and provides a structured summary',
+  agent: searchResearcher,
+  expectedOutput: 'A well-formatted analysis of the search results',
+});
+
+const team = new Team({
+  name: 'Search Analysis Unit',
+  description: 'Specialized team for web search and analysis',
+  agents: [searchResearcher],
+  tasks: [searchAnalysisTask],
+  inputs: {
+    searchQuery: 'What are the latest developments in AI?',
+  },
+  env: {
+    OPENAI_API_KEY: import.meta.env.VITE_OPENAI_API_KEY,
+    GOOGLE_API_KEY: import.meta.env.VITE_GOOGLE_API_KEY,
+  },
+});
+
+export const Default = {
+  args: {
+    toolInstance: perplexityTool,
+    callParams: {
+      searchQuery: 'What are the latest developments in AI?',
+    },
+  },
+};
+
+export const withAgent = {
+  render: (args) => <AgentWithToolPreviewer {...args} />,
+  args: {
+    team: team,
+  },
+};

--- a/packages/tools/src/perplexity-search/tool.test.js
+++ b/packages/tools/src/perplexity-search/tool.test.js
@@ -1,0 +1,284 @@
+const {
+  PerplexitySearch,
+} = require('../../dist/perplexity-search/index.cjs.js');
+
+describe('PerplexitySearch', () => {
+  const sampleResults = [
+    {
+      title: 'Latest AI News',
+      url: 'https://example.com/ai-news',
+      snippet: 'Recent developments in artificial intelligence...',
+      date: '2026-04-01',
+    },
+    {
+      title: 'AI in Healthcare',
+      url: 'https://example.com/ai-healthcare',
+      snippet: 'How AI is transforming healthcare...',
+    },
+  ];
+
+  test('sends correct default parameters and normalizes results', async () => {
+    const tool = new PerplexitySearch({ apiKey: 'test-api-key' });
+
+    let capturedRequest;
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          (request) => {
+            capturedRequest = request;
+            return new Response(
+              JSON.stringify({ id: 'abc', results: sampleResults }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }
+            );
+          },
+        ],
+      },
+    });
+
+    const result = await tool._call({ searchQuery: 'latest AI developments' });
+
+    expect(capturedRequest.url).toBe('https://api.perplexity.ai/search');
+    expect(capturedRequest.method).toBe('POST');
+    expect(capturedRequest.headers.get('Authorization')).toBe(
+      'Bearer test-api-key'
+    );
+    expect(capturedRequest.headers.get('Content-Type')).toBe(
+      'application/json'
+    );
+
+    const body = await capturedRequest.json();
+    expect(body).toEqual({
+      query: 'latest AI developments',
+      max_results: 10,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual([
+      {
+        title: 'Latest AI News',
+        url: 'https://example.com/ai-news',
+        snippet: 'Recent developments in artificial intelligence...',
+        date: '2026-04-01',
+      },
+      {
+        title: 'AI in Healthcare',
+        url: 'https://example.com/ai-healthcare',
+        snippet: 'How AI is transforming healthcare...',
+      },
+    ]);
+  });
+
+  test('forwards maxResults, searchDomainFilter and searchRecencyFilter', async () => {
+    const tool = new PerplexitySearch({
+      apiKey: 'test-api-key',
+      maxResults: 3,
+      searchDomainFilter: ['nytimes.com', '-pinterest.com'],
+      searchRecencyFilter: 'month',
+    });
+
+    let capturedRequest;
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          (request) => {
+            capturedRequest = request;
+            return new Response(JSON.stringify({ results: sampleResults }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          },
+        ],
+      },
+    });
+
+    await tool._call({ searchQuery: 'climate news' });
+
+    const body = await capturedRequest.json();
+    expect(body).toEqual({
+      query: 'climate news',
+      max_results: 3,
+      search_domain_filter: ['nytimes.com', '-pinterest.com'],
+      search_recency_filter: 'month',
+    });
+  });
+
+  test('reads API key from PERPLEXITY_API_KEY env var', async () => {
+    const original = process.env.PERPLEXITY_API_KEY;
+    process.env.PERPLEXITY_API_KEY = 'env-api-key';
+    try {
+      const tool = new PerplexitySearch();
+
+      let capturedRequest;
+      tool.httpClient = tool.httpClient.extend({
+        hooks: {
+          beforeRequest: [
+            (request) => {
+              capturedRequest = request;
+              return new Response(JSON.stringify({ results: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              });
+            },
+          ],
+        },
+      });
+
+      await tool._call({ searchQuery: 'q' });
+      expect(capturedRequest.headers.get('Authorization')).toBe(
+        'Bearer env-api-key'
+      );
+    } finally {
+      if (original === undefined) {
+        delete process.env.PERPLEXITY_API_KEY;
+      } else {
+        process.env.PERPLEXITY_API_KEY = original;
+      }
+    }
+  });
+
+  test('reads API key from PPLX_API_KEY env var', async () => {
+    const originalPpl = process.env.PERPLEXITY_API_KEY;
+    const originalPplx = process.env.PPLX_API_KEY;
+    delete process.env.PERPLEXITY_API_KEY;
+    process.env.PPLX_API_KEY = 'pplx-env-api-key';
+    try {
+      const tool = new PerplexitySearch();
+
+      let capturedRequest;
+      tool.httpClient = tool.httpClient.extend({
+        hooks: {
+          beforeRequest: [
+            (request) => {
+              capturedRequest = request;
+              return new Response(JSON.stringify({ results: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              });
+            },
+          ],
+        },
+      });
+
+      await tool._call({ searchQuery: 'q' });
+      expect(capturedRequest.headers.get('Authorization')).toBe(
+        'Bearer pplx-env-api-key'
+      );
+    } finally {
+      if (originalPpl === undefined) {
+        delete process.env.PERPLEXITY_API_KEY;
+      } else {
+        process.env.PERPLEXITY_API_KEY = originalPpl;
+      }
+      if (originalPplx === undefined) {
+        delete process.env.PPLX_API_KEY;
+      } else {
+        process.env.PPLX_API_KEY = originalPplx;
+      }
+    }
+  });
+
+  test('throws when no API key is provided and no env var is set', () => {
+    const originalPpl = process.env.PERPLEXITY_API_KEY;
+    const originalPplx = process.env.PPLX_API_KEY;
+    delete process.env.PERPLEXITY_API_KEY;
+    delete process.env.PPLX_API_KEY;
+    try {
+      expect(() => new PerplexitySearch()).toThrow(/missing API key/i);
+    } finally {
+      if (originalPpl !== undefined) process.env.PERPLEXITY_API_KEY = originalPpl;
+      if (originalPplx !== undefined) process.env.PPLX_API_KEY = originalPplx;
+    }
+  });
+
+  test('returns a parse error message when the response shape is invalid', async () => {
+    const tool = new PerplexitySearch({ apiKey: 'test-api-key' });
+
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          () =>
+            new Response(JSON.stringify({ id: 'no-results-here' }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+        ],
+      },
+    });
+
+    const result = await tool._call({ searchQuery: 'q' });
+    expect(result).toBe(
+      'Could not parse Perplexity search results. Please try again.'
+    );
+  });
+
+  test('handles client error (4xx)', async () => {
+    const tool = new PerplexitySearch({ apiKey: 'test-api-key' });
+
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          () =>
+            new Response(
+              JSON.stringify({ error: 'invalid api key' }),
+              { status: 401, headers: { 'Content-Type': 'application/json' } }
+            ),
+        ],
+      },
+    });
+
+    const result = await tool._call({ searchQuery: 'q' });
+    expect(result).toBe('API request failed: Client Error (401)');
+  });
+
+  test('handles server error (5xx)', async () => {
+    const tool = new PerplexitySearch({ apiKey: 'test-api-key' });
+
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          () =>
+            new Response(
+              JSON.stringify({ error: 'oops' }),
+              { status: 500, headers: { 'Content-Type': 'application/json' } }
+            ),
+        ],
+      },
+    });
+
+    const result = await tool._call({ searchQuery: 'q' });
+    expect(result).toBe('API request failed: Server Error (500)');
+  });
+
+  test('handles unexpected errors', async () => {
+    const tool = new PerplexitySearch({ apiKey: 'test-api-key' });
+
+    tool.httpClient = tool.httpClient.extend({
+      hooks: {
+        beforeRequest: [
+          () => {
+            throw new Error('Network Error');
+          },
+        ],
+      },
+    });
+
+    const result = await tool._call({ searchQuery: 'q' });
+    expect(result).toBe('An unexpected error occurred: Network Error');
+  });
+
+  test('is exported correctly in both paths', () => {
+    const {
+      PerplexitySearch: PerplexitySearchScoped,
+    } = require('../../dist/perplexity-search/index.cjs.js');
+    const {
+      PerplexitySearch: PerplexitySearchMain,
+    } = require('../../dist/index.cjs.js');
+
+    expect(typeof PerplexitySearchScoped).toBe('function');
+    expect(typeof PerplexitySearchMain).toBe('function');
+    expect(PerplexitySearchScoped.name).toBe(PerplexitySearchMain.name);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `PerplexitySearch` tool to `@kaibanjs/tools` that wraps `POST https://api.perplexity.ai/search` and returns structured `{ title, url, snippet, date? }` results, modeled after the existing Tavily / Exa / Serper search tools.

## What's new

- New tool: `packages/tools/src/perplexity-search/` (TS + JS implementations matching the existing tool pattern)
- Constructor accepts `apiKey` directly, or falls back to the `PERPLEXITY_API_KEY` / `PPLX_API_KEY` environment variable
- Configurable options: `maxResults`, `searchDomainFilter` (allow- or deny-list — leading `-` for deny), `searchRecencyFilter` (`hour | day | week | month | year`)
- Registered in `src/index.ts` exports, `package.json` subpath exports, and `rollup.config.mjs` build targets
- README + Storybook story added; package-level README table updated

## Tests

10 Jest tests in `src/perplexity-search/tool.test.js` covering:
- default request shape and result normalization
- forwarding of `maxResults`, `searchDomainFilter`, `searchRecencyFilter`
- API-key resolution from `PERPLEXITY_API_KEY` and `PPLX_API_KEY` env vars
- error when no API key is provided
- invalid response shape, 4xx, 5xx, and network-error paths
- export equivalence between `dist/perplexity-search/index.cjs.js` and `dist/index.cjs.js`

Run:

```bash
cd packages/tools
npm install
npm run build
npx jest src/perplexity-search/tool.test.js
```

All 10 tests pass locally.

## Reference

- API reference: https://docs.perplexity.ai/api-reference/search-post
- Domain filter docs: https://docs.perplexity.ai/docs/search/filters/domain-filter
- Date / recency filter docs: https://docs.perplexity.ai/docs/search/filters/date-time-filters
